### PR TITLE
DEV: Fix failing spec

### DIFF
--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe GroupsController do
   before { SiteSetting.group_tag_associations_enabled = true }
 
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user)
   let(:group) { Fabricate(:group, users: [user]) }
 
   describe "#posts" do
@@ -33,7 +33,8 @@ describe GroupsController do
       get "/groups/#{group.name}/posts.json"
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body.first["id"]).to eq(post.id)
+
+      expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
     end
 
     fab!(:tag1) { Fabricate(:tag, name: "fun") }
@@ -48,7 +49,7 @@ describe GroupsController do
       get "/groups/#{group.name}/posts.json"
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body.first["id"]).to eq(tagged_post.id)
+      expect(response.parsed_body["posts"].first["id"]).to eq(tagged_post.id)
     end
   end
 end


### PR DESCRIPTION
Regressed after this core change
https://github.com/discourse/discourse/pull/26663

because the signature of the endpoint changed. Looks like only tests were affected.