### PR TITLE
FIX: Hidden post excerpts could be leaked via associated-tag group posts feed

### DIFF
--- a/lib/discourse_group_tag_associations/group_extension.rb
+++ b/lib/discourse_group_tag_associations/group_extension.rb
@@ -23,15 +23,7 @@ module DiscourseGroupTagAssociations
             .where(post_type: [Post.types[:regular], Post.types[:moderator_action]])
             .where("tags.name IN (:tags)", tags: associated_tags)
 
-        if opts[:category_id].present?
-          tag_results = tag_results.where("topics.category_id = ?", opts[:category_id].to_i)
-        end
-
-        tag_results = guardian.filter_allowed_categories(tag_results)
-        tag_results = tag_results.where("posts.id < ?", opts[:before_post_id].to_i) if opts[
-          :before_post_id
-        ]
-        tag_results.order("posts.created_at desc")
+        filter_posts_for_guardian(tag_results, guardian, opts)
       else
         super
       end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -66,6 +66,47 @@ describe GroupsController do
       )
       expect(response.body).not_to include(hidden_post.raw)
     end
+
+    it "still includes the viewer's own hidden posts from associated tags", :aggregate_failures do
+      sign_in(user)
+
+      own_hidden_post =
+        Fabricate(:post, topic: tagged_topic, user: user, raw: "my own hidden post", hidden: true)
+      group.update!(associated_tags: [tag1.name])
+
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].map { |post| post["id"] }).to include(own_hidden_post.id)
+    end
+
+    it "includes hidden posts from associated tags for staff", :aggregate_failures do
+      sign_in(Fabricate(:admin))
+
+      hidden_post =
+        Fabricate(:post, topic: tagged_topic, raw: "hidden tagged group post", hidden: true)
+      group.update!(associated_tags: [tag1.name])
+
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].map { |post| post["id"] }).to include(hidden_post.id)
+    end
+
+    it "omits hidden posts from associated tags for anonymous users", :aggregate_failures do
+      visible_post = Fabricate(:post, topic: tagged_topic, raw: "visible tagged group post")
+      hidden_post =
+        Fabricate(:post, topic: tagged_topic, raw: "hidden tagged group post", hidden: true)
+      group.update!(associated_tags: [tag1.name])
+
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
+        visible_post.id,
+      )
+      expect(response.body).not_to include(hidden_post.raw)
+    end
   end
 
   describe "#posts_feed" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -49,5 +49,42 @@ describe GroupsController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["posts"].first["id"]).to eq(tagged_post.id)
     end
+
+    it "omits hidden posts from associated tags", :aggregate_failures do
+      sign_in(user)
+
+      visible_post = Fabricate(:post, topic: tagged_topic, raw: "visible tagged group post")
+      hidden_post =
+        Fabricate(:post, topic: tagged_topic, raw: "hidden tagged group post", hidden: true)
+      group.update!(associated_tags: [tag1.name])
+
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
+        visible_post.id,
+      )
+      expect(response.body).not_to include(hidden_post.raw)
+    end
+  end
+
+  describe "#posts_feed" do
+    fab!(:tag1) { Fabricate(:tag, name: "fun") }
+    fab!(:tagged_topic) { Fabricate(:topic, tags: [tag1]) }
+
+    it "omits hidden posts from associated tags", :aggregate_failures do
+      sign_in(user)
+
+      visible_post = Fabricate(:post, topic: tagged_topic, raw: "visible tagged group rss post")
+      hidden_post =
+        Fabricate(:post, topic: tagged_topic, raw: "hidden tagged group rss post", hidden: true)
+      group.update!(associated_tags: [tag1.name])
+
+      get "/groups/#{group.name}/posts.rss"
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include(visible_post.raw)
+      expect(response.body).not_to include(hidden_post.raw)
+    end
   end
 end


### PR DESCRIPTION
Some spam posts that are hidden may be exposed via the associated-tag group posts feed.

This happened in the .json and .rss APIs

We updated the manual filtering with `filter_posts_for_guardian` from core 
Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>

relates to patch-triage/1238