### PR TITLE
FIX: Prevent hidden tag visibility bypass in group associations

### DIFF
--- a/app/models/group_tag_association.rb
+++ b/app/models/group_tag_association.rb
@@ -4,14 +4,23 @@ class GroupTagAssociation < ActiveRecord::Base
   belongs_to :group
   belongs_to :tag
 
-  def self.batch_set(group, tag_names)
+  def self.batch_set(group, tag_names, guardian = nil)
     tag_names ||= []
-    self.where(group: group).destroy_all
+
+    visible_tags = DiscourseTagging.filter_visible(Tag, guardian)
+
+    self.where(group: group, tag_id: visible_tags.select(:id)).destroy_all
 
     if tag_names.length > 0
-      tag_ids = Set.new(Tag.where_name(tag_names).pluck(:id))
+      tag_ids = Set.new(visible_tags.where_name(tag_names).pluck(:id))
       tag_ids.each { |id| self.create!(group: group, tag_id: id) }
     end
+  end
+
+  def self.tag_names_for(group, guardian = nil)
+    visible_tags = DiscourseTagging.filter_visible(Tag, guardian)
+
+    self.where(group_id: group.id, tag_id: visible_tags.select(:id)).joins(:tag).pluck("tags.name")
   end
 end
 

--- a/lib/discourse_group_tag_associations/group_extension.rb
+++ b/lib/discourse_group_tag_associations/group_extension.rb
@@ -10,7 +10,9 @@ module DiscourseGroupTagAssociations
     end
 
     def posts_for(guardian, opts = nil)
-      if SiteSetting.group_tag_associations_enabled && associated_tags.present?
+      associated_tag_names = associated_tags(guardian) if SiteSetting.group_tag_associations_enabled
+
+      if associated_tag_names.present?
         opts ||= {}
 
         tag_results =
@@ -21,7 +23,7 @@ module DiscourseGroupTagAssociations
             .where("topics.visible")
             .where("topics.archetype <> ?", Archetype.private_message)
             .where(post_type: [Post.types[:regular], Post.types[:moderator_action]])
-            .where("tags.name IN (:tags)", tags: associated_tags)
+            .where("tags.name IN (:tags)", tags: associated_tag_names)
 
         filter_posts_for_guardian(tag_results, guardian, opts)
       else

--- a/lib/discourse_group_tag_associations/groups_controller_extension.rb
+++ b/lib/discourse_group_tag_associations/groups_controller_extension.rb
@@ -4,10 +4,13 @@ module DiscourseGroupTagAssociations
   module GroupsControllerExtension
     extend ActiveSupport::Concern
 
-    def group_params(automatic: false)
+    def group_params(automatic: false, group: nil)
       core_params = super
-      if params[:group][:associated_tags]
-        core_params.merge!(associated_tags: params[:group][:associated_tags])
+      if params[:group].key?(:associated_tags)
+        core_params.merge!(
+          associated_tags: params[:group][:associated_tags],
+          associated_tags_guardian: guardian,
+        )
       else
         core_params
       end

--- a/lib/discourse_group_tag_associations/topic_query_extension.rb
+++ b/lib/discourse_group_tag_associations/topic_query_extension.rb
@@ -5,7 +5,7 @@ module DiscourseGroupTagAssociations
     extend ActiveSupport::Concern
 
     def list_group_topics(group)
-      associated_tags = Group.find(group.id.to_i).associated_tags
+      associated_tags = Group.find(group.id.to_i).associated_tags(guardian)
 
       if SiteSetting.group_tag_associations_enabled && associated_tags.present?
         list = default_results.joins(topic_tags: :tag).where("tags.name IN (?)", associated_tags)

--- a/plugin.rb
+++ b/plugin.rb
@@ -19,13 +19,17 @@ after_initialize do
   require_relative "lib/discourse_group_tag_associations/groups_controller_extension"
 
   add_to_class(:group, :set_tag_associations) do
-    GroupTagAssociation.batch_set(self, @associated_tags)
+    GroupTagAssociation.batch_set(self, @associated_tags, @associated_tags_guardian)
   end
 
   add_to_class(:group, "associated_tags=") { |tag_names| @associated_tags = tag_names }
 
-  add_to_class(:group, :associated_tags) do
-    GroupTagAssociation.where(group_id: id).joins(:tag).pluck(:name)
+  add_to_class(:group, "associated_tags_guardian=") do |guardian|
+    @associated_tags_guardian = guardian
+  end
+
+  add_to_class(:group, :associated_tags) do |guardian = nil|
+    GroupTagAssociation.tag_names_for(self, guardian)
   end
 
   reloadable_patch do
@@ -34,7 +38,5 @@ after_initialize do
     GroupsController.prepend(DiscourseGroupTagAssociations::GroupsControllerExtension)
   end
 
-  add_to_serializer(:group_show, :associated_tags) do
-    GroupTagAssociation.where(group_id: object.id).joins(:tag).pluck(:name)
-  end
+  add_to_serializer(:group_show, :associated_tags) { object.associated_tags(scope) }
 end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -128,4 +128,164 @@ describe GroupsController do
       expect(response.body).not_to include(hidden_post.raw)
     end
   end
+
+  describe "#update" do
+    fab!(:group_owner, :user)
+    fab!(:regular_user, :user)
+    fab!(:admin)
+    fab!(:owned_group) { Fabricate(:group, users: [group_owner]) }
+
+    fab!(:public_tag) { Fabricate(:tag, name: "public-tag") }
+    fab!(:hidden_tag) { Fabricate(:tag, name: "hidden") }
+    fab!(:hidden_tag_group) do
+      Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
+    end
+
+    fab!(:public_topic_with_hidden_tag) { Fabricate(:topic, tags: [hidden_tag]) }
+    fab!(:public_topic_with_public_tag) { Fabricate(:topic, tags: [public_tag]) }
+
+    before { GroupUser.where(group: owned_group, user: group_owner).update_all(owner: true) }
+
+    context "when a group owner tries to associate a tag" do
+      it "should NOT allow associating hidden tags" do
+        sign_in(group_owner)
+
+        put "/groups/#{owned_group.id}.json",
+            params: {
+              group: {
+                associated_tags: [hidden_tag.name],
+              },
+            }
+
+        expect(response.status).to eq(200)
+
+        owned_group.reload
+        associated_tag_ids = GroupTagAssociation.where(group: owned_group).pluck(:tag_id)
+
+        expect(associated_tag_ids).not_to include(hidden_tag.id)
+      end
+
+      it "should allow associating public tags" do
+        sign_in(group_owner)
+
+        put "/groups/#{owned_group.id}.json",
+            params: {
+              group: {
+                associated_tags: [public_tag.name],
+              },
+            }
+
+        expect(response.status).to eq(200)
+
+        owned_group.reload
+        associated_tag_ids = GroupTagAssociation.where(group: owned_group).pluck(:tag_id)
+
+        expect(associated_tag_ids).to include(public_tag.id)
+        expect(associated_tag_ids).not_to include(hidden_tag.id)
+      end
+    end
+
+    context "when a user tries to discover topics via hidden tag association" do
+      it "should NOT expose topics tagged with hidden tags (information disclosure test)" do
+        sign_in(group_owner)
+
+        GroupTagAssociation.create!(group: owned_group, tag: hidden_tag)
+
+        get "/topics/groups/#{owned_group.name}.json"
+
+        expect(response.status).to eq(200)
+        topic_ids = response.parsed_body["topic_list"]["topics"].map { |t| t["id"] }
+
+        expect(topic_ids).not_to include(public_topic_with_hidden_tag.id)
+      end
+
+      it "should expose topics tagged with public tags" do
+        sign_in(group_owner)
+
+        GroupTagAssociation.create!(group: owned_group, tag: public_tag)
+
+        get "/topics/groups/#{owned_group.name}.json"
+
+        expect(response.status).to eq(200)
+        topic_ids = response.parsed_body["topic_list"]["topics"].map { |t| t["id"] }
+
+        expect(topic_ids).to include(public_topic_with_public_tag.id)
+        expect(topic_ids).not_to include(public_topic_with_hidden_tag.id)
+      end
+    end
+
+    context "when viewing group details" do
+      it "should NOT expose hidden tag names to unauthorized users" do
+        sign_in(group_owner)
+
+        GroupTagAssociation.create!(group: owned_group, tag: public_tag)
+        GroupTagAssociation.create!(group: owned_group, tag: hidden_tag)
+
+        get "/groups/#{owned_group.name}.json"
+
+        expect(response.status).to eq(200)
+        associated_tags = response.parsed_body["group"]["associated_tags"]
+
+        expect(associated_tags).not_to include(hidden_tag.name)
+        expect(associated_tags).to include(public_tag.name)
+      end
+
+      it "should expose all associated tags (including hidden) to admins" do
+        sign_in(admin)
+
+        GroupTagAssociation.create!(group: owned_group, tag: public_tag)
+        GroupTagAssociation.create!(group: owned_group, tag: hidden_tag)
+
+        get "/groups/#{owned_group.name}.json"
+
+        expect(response.status).to eq(200)
+        associated_tags = response.parsed_body["group"]["associated_tags"]
+
+        expect(associated_tags).to include(hidden_tag.name)
+        expect(associated_tags).to include(public_tag.name)
+      end
+    end
+
+    it "prevents anonymous users from updating group tags" do
+      put "/groups/#{owned_group.id}.json",
+          params: {
+            group: {
+              associated_tags: [public_tag.name],
+            },
+          }
+
+      expect(response.status).to eq(403)
+    end
+
+    it "prevents regular users (non-owners) from updating group tags" do
+      sign_in(regular_user)
+
+      put "/groups/#{owned_group.id}.json",
+          params: {
+            group: {
+              associated_tags: [public_tag.name],
+            },
+          }
+
+      expect(response.status).to eq(403)
+    end
+
+    it "allows staff to update any group tags" do
+      sign_in(admin)
+
+      put "/groups/#{owned_group.id}.json",
+          params: {
+            group: {
+              associated_tags: [hidden_tag.name],
+            },
+          }
+
+      expect(response.status).to eq(200)
+
+      owned_group.reload
+      associated_tag_ids = GroupTagAssociation.where(group: owned_group).pluck(:tag_id)
+
+      expect(associated_tag_ids).to include(hidden_tag.id)
+    end
+  end
 end


### PR DESCRIPTION
#### Description
Non-staff group owners could associate their groups with `hidden tags`, then use plugin endpoints to discover which `public topics` were tagged with those restricted tags, bypassing Discourse's tag visibility rules.

This PR removes this issue and also blocks users from bypassing Discourse's tag visibility rules, even on already existing problematic `GroupTag` associations.

Also fixes compatibility with Discourse core since April 2026 by updating `group_params` method signature to accept `group:` parameter (commit [f168d765064](https://github.com/discourse/discourse/pull/39651)).

Context: `patch-triage/1237`